### PR TITLE
Add dynamic sqlite version 3 module for powerdns

### DIFF
--- a/net/powerdns-sqlite3/DESCR
+++ b/net/powerdns-sqlite3/DESCR
@@ -1,0 +1,9 @@
+The PowerDNS nameserver is a modern, advanced and high performance
+authoritative-only nameserver.  It is written from scratch and conforms
+to all the relevant DNS standards documents.  PowerDNS is open source.
+
+The PowerDNS nameserver utilizes a flexible backend architecture that
+can access DNS information from any data source.  This includes file
+formats, BIND zone files, relational databases or LDAP directories.
+
+This packages provides the SQLite version 3 backend module.

--- a/net/powerdns-sqlite3/Makefile
+++ b/net/powerdns-sqlite3/Makefile
@@ -1,0 +1,14 @@
+# $NetBSD: Makefile,v 1.0 2013/08/31 20:19:00 tm Exp $
+
+.include "../../net/powerdns/Makefile.backend"
+
+PKGNAME=		${DISTNAME:S/pdns/powerdns-sqlite3/}
+PKGREVISION=		1
+COMMENT=		SQLite version 3 backend module for PowerDNS
+
+CONFIGURE_ARGS+=	--with-dynmodules="gsqlite3"
+CONFIGURE_ARGS+=	--with-sqlite3-lib=${BUILDLINK_PREFIX.sqlite3}/lib
+CONFIGURE_ARGS+=	--with-sqlite3-includes=${BUILDLINK_PREFIX.sqlite3}/include
+
+.include "../../databases/sqlite3/buildlink3.mk"
+.include "../../mk/bsd.pkg.mk"

--- a/net/powerdns-sqlite3/PLIST
+++ b/net/powerdns-sqlite3/PLIST
@@ -1,0 +1,2 @@
+@comment $NetBSD$
+lib/pdns/libgsqlite3backend.la


### PR DESCRIPTION
Hello,

it would be awesome if you support the dynamic module for powerdns. This module allows the usage of sqlite version 3 with powerdns. The benefit will be the usage of DNSSEC with the backend.

Best regards,
Thomas
