### PR TITLE
Workaround for missing local on SmartOS / Solaris. Using typeset instead...

### DIFF
--- a/mail/exim/distinfo
+++ b/mail/exim/distinfo
@@ -7,3 +7,4 @@ SHA1 (patch-aa) = 24a12631b7df17930349b8a0d03adc80d27efbe2
 SHA1 (patch-ab) = 6af17f036ed02a3bc37c1f303269eea447fcb691
 SHA1 (patch-ae) = 7daf63727e222bbaa7e5b8289c4fcb6a8c0272cf
 SHA1 (patch-ag) = dd93bb718c996f18b4e985806eb6d4ff5f25a67f
+SHA1 (patch-lookupsMakefile) = 303ab11d16e36190dba3041ee0fa1b4455d6d0c6

--- a/mail/exim/distinfo
+++ b/mail/exim/distinfo
@@ -7,4 +7,4 @@ SHA1 (patch-aa) = 24a12631b7df17930349b8a0d03adc80d27efbe2
 SHA1 (patch-ab) = 6af17f036ed02a3bc37c1f303269eea447fcb691
 SHA1 (patch-ae) = 7daf63727e222bbaa7e5b8289c4fcb6a8c0272cf
 SHA1 (patch-ag) = dd93bb718c996f18b4e985806eb6d4ff5f25a67f
-SHA1 (patch-lookupsMakefile) = 303ab11d16e36190dba3041ee0fa1b4455d6d0c6
+SHA1 (patch-lookupsMakefile) = 3bb52d8820de9707b0212d26443ded89bb282f35

--- a/mail/exim/patches/patch-lookupsMakefile
+++ b/mail/exim/patches/patch-lookupsMakefile
@@ -1,0 +1,10 @@
+$NetBSD$
+
+--- scripts/lookups-Makefile.orig       2013-08-31 20:11:09.363021248 +0000
++++ scripts/lookups-Makefile
+@@ -1,4 +1,5 @@
+ #! /bin/sh
++alias local=typeset
+ 
+ # We turn the configure-built build-$foo/lookups/Makefile.predynamic into Makefile
+ 

--- a/mail/exim/patches/patch-lookupsMakefile
+++ b/mail/exim/patches/patch-lookupsMakefile
@@ -1,10 +1,35 @@
 $NetBSD$
 
---- scripts/lookups-Makefile.orig       2013-08-31 20:11:09.363021248 +0000
+--- scripts/lookups-Makefile.orig       2012-10-25 03:37:38.000000000 +0000
 +++ scripts/lookups-Makefile
-@@ -1,4 +1,5 @@
- #! /bin/sh
-+alias local=typeset
+@@ -62,16 +62,16 @@ tmp="$target.t"
+ # command-line, not just check the Makefile.
  
- # We turn the configure-built build-$foo/lookups/Makefile.predynamic into Makefile
+ want_dynamic() {
+-  local dyn_name="$1"
+-  local re="LOOKUP_${dyn_name}[ $tab]*=[ $tab]*2"
++  dyn_name="$1"
++  re="LOOKUP_${dyn_name}[ $tab]*=[ $tab]*2"
+   env | grep -q "^$re"
+   if [ $? -eq 0 ]; then return 0; fi
+   grep -q "^[ $tab]*$re" "$defs_source"
+ }
  
+ want_at_all() {
+-  local want_name="$1"
+-  local re="LOOKUP_${want_name}[ $tab]*=[ $tab]*."
++  want_name="$1"
++  re="LOOKUP_${want_name}[ $tab]*=[ $tab]*."
+   env | grep -q "^$re"
+   if [ $? -eq 0 ]; then return 0; fi
+   grep -q "^[ $tab]*$re" "$defs_source"
+@@ -83,8 +83,7 @@ MODS=""
+ OBJ=""
+ 
+ emit_module_rule() {
+-  local lookup_name="$1"
+-  local mod_name pkgconf
++  lookup_name="$1"
+   if [ "${lookup_name%:*}" = "$lookup_name" ]
+   then
+     mod_name=$(echo $lookup_name | tr A-Z a-z)


### PR DESCRIPTION
To build exim version 4 on SmartOS I using `typeset` on the `scripts/lookups-Makefile`. I'm not 100% sure if `typeset` also exists on BSD and work there as well.
