### PR TITLE
ipv6calc: update to 0.94.1

### DIFF
--- a/net/ipv6calc/Makefile
+++ b/net/ipv6calc/Makefile
@@ -1,7 +1,7 @@
 # $NetBSD: Makefile,v 1.36 2012/10/23 17:18:29 asau Exp $
 #
 
-DISTNAME=	ipv6calc-0.72.1
+DISTNAME=	ipv6calc-0.94.1
 CATEGORIES=	net
 MASTER_SITES=	ftp://ftp.bieringer.de/pub/linux/IPv6/ipv6calc/ \
 		ftp://sunsite.icm.edu.pl/pub/Linux/ipv6/bipv6/ipv6calc/
@@ -9,6 +9,7 @@ MASTER_SITES=	ftp://ftp.bieringer.de/pub/linux/IPv6/ipv6calc/ \
 MAINTAINER=	pkgsrc-users@NetBSD.org
 HOMEPAGE=	http://www.deepspace6.net/projects/ipv6calc.html
 COMMENT=	Manipulates IPv6 addresses
+LICENSE=	gnu-gpl-v2
 
 # This package does not set or evaluate IPV6_READY, but it should still
 # be listed in README-IPv6.html. Leave this comment here to make it so!

--- a/net/ipv6calc/distinfo
+++ b/net/ipv6calc/distinfo
@@ -1,5 +1,5 @@
 $NetBSD: distinfo,v 1.15 2009/01/12 22:25:23 hubertf Exp $
 
-SHA1 (ipv6calc-0.72.1.tar.gz) = 9a8de514fd9806d97b74cc3f2fda042c33c29961
-RMD160 (ipv6calc-0.72.1.tar.gz) = 3c52b49ff7a99cd7b3d5dc01e67ba955dd4a7b73
-Size (ipv6calc-0.72.1.tar.gz) = 549732 bytes
+SHA1 (ipv6calc-0.94.1.tar.gz) = c36689ed84472bb39897167fea14529b06da4647
+RMD160 (ipv6calc-0.94.1.tar.gz) = f1baffbe2f1b3a71d85f311fe735b97e1d45d7da
+Size (ipv6calc-0.94.1.tar.gz) = 749953 bytes


### PR DESCRIPTION
- update ipv6calc version to 0.94.1
- add license information
