### PR TITLE
miniupnpd: update to 1.8, fix build on SmartOS

### DIFF
--- a/net/miniupnpd/Makefile
+++ b/net/miniupnpd/Makefile
@@ -1,6 +1,6 @@
 # $NetBSD: Makefile,v 1.8 2012/11/20 11:21:59 abs Exp $
 
-DISTNAME=	miniupnpd-1.6.20120320
+DISTNAME=	miniupnpd-1.8.20130730
 PKGREVISION=	1
 CATEGORIES=	net
 MASTER_SITES=	http://miniupnp.free.fr/files/download.php?file=

--- a/net/miniupnpd/distinfo
+++ b/net/miniupnpd/distinfo
@@ -1,6 +1,9 @@
 $NetBSD: distinfo,v 1.7 2012/12/20 21:39:28 joerg Exp $
 
-SHA1 (miniupnpd-1.6.20120320.tar.gz) = f99a6f102e02a37e6d048814ea3e5aed9214998d
-RMD160 (miniupnpd-1.6.20120320.tar.gz) = cb7da6525d8d1a5ddc9deab07dc2289cca63fd71
-Size (miniupnpd-1.6.20120320.tar.gz) = 127968 bytes
-SHA1 (patch-Makefile) = d72485512b099ed9c26df16a7412958a715ffa8d
+SHA1 (miniupnpd-1.8.20130730.tar.gz) = 32eed969a6c653d6d5ccd236ee50275c933d020e
+RMD160 (miniupnpd-1.8.20130730.tar.gz) = 1d7488a2567c1eb72393c61be462f893b5519285
+Size (miniupnpd-1.8.20130730.tar.gz) = 149904 bytes
+SHA1 (patch-Makefile) = 622cfcaf46259dec41cf5bb9d11e6b5a2fa2830d
+SHA1 (patch-bsd_getroute.c) = 0649c6e3febc2bac008f4325f71c64c99200c216
+SHA1 (patch-bsd_ifacewatcher.c) = 3a9fdf12e721c1452bc34bf2a4938ae5d492a0f0
+SHA1 (patch-upnputils.h) = a948bc7e77a9ef105f72b28f97498b329849e31f

--- a/net/miniupnpd/patches/patch-Makefile
+++ b/net/miniupnpd/patches/patch-Makefile
@@ -1,33 +1,42 @@
-$NetBSD: patch-Makefile,v 1.3 2012/12/20 21:39:28 joerg Exp $
+$NetBSD$
 
-* Honor user setting CFLAGS.
-* Do not override FWNAME if passed in
-
---- Makefile.orig	2012-03-05 20:37:13.000000000 +0000
+add missing linker flags
+--- Makefile.orig	2013-02-06 13:14:42.000000000 +0000
 +++ Makefile
-@@ -11,7 +11,7 @@
- # Linux users, please use Makefile.linux :
- #  make -f Makefile.linux
+@@ -17,7 +17,7 @@
  
--CFLAGS = -pipe -Wall -Os -ansi
-+CFLAGS += -Wall
- #CFLAGS = -pipe -Wall -O -g -DDEBUG -ansi
- CC ?= gcc
- RM = rm -f
-@@ -28,7 +28,6 @@ FWNAME = pf
- .else
- FWNAME = ipf
- .endif
--.endif
+ CFLAGS ?= -pipe -Os
+ #CFLAGS = -pipe -O -g -DDEBUG
+-CFLAGS += -ansi
++#CFLAGS += -ansi
+ CFLAGS += -Wall
+ CFLAGS += -W
+ CFLAGS += -Wstrict-prototypes
+@@ -182,22 +182,22 @@ miniupnpd: config.h $(ALLOBJS)
+ #	$(CC) $(CFLAGS) -o $@ $> $(LIBS)
  
- # better way to find if we are using ipf or pf
- .if $(OSNAME) == "FreeBSD"
-@@ -53,6 +52,8 @@ FWNAME != . /etc/rc.subr; . /etc/rc.conf
- FWNAME = ipfw
- .endif
+ miniupnpdctl:	config.h $(MINIUPNPDCTLOBJS)
+-	$(CC) $(CFLAGS) -o $@ $(MINIUPNPDCTLOBJS)
++	$(CC) $(CFLAGS) -o $@ $(MINIUPNPDCTLOBJS) $(LIBS)
  
-+.endif
-+
- # Solaris specific CFLAGS
- .if $(OSNAME) == "SunOS"
- CFLAGS += -DSOLARIS2=`uname -r | cut -d. -f2`
+ testupnpdescgen:	config.h $(TESTUPNPDESCGENOBJS)
+-	$(CC) $(CFLAGS) -o $@ $(TESTUPNPDESCGENOBJS)
++	$(CC) $(CFLAGS) -o $@ $(TESTUPNPDESCGENOBJS) $(LIBS)
+ 
+ testgetifstats:	config.h $(TESTGETIFSTATSOBJS)
+ 	$(CC) $(CFLAGS) -o $@ $(TESTGETIFSTATSOBJS) $(LIBS)
+ 
+ testgetifaddr:	config.h $(TESTGETIFADDROBJS)
+-	$(CC) $(CFLAGS) -o $@ $(TESTGETIFADDROBJS)
++	$(CC) $(CFLAGS) -o $@ $(TESTGETIFADDROBJS) $(LIBS)
+ 
+ testupnppermissions:	config.h $(TESTUPNPPERMISSIONSOBJS)
+-	$(CC) $(CFLAGS) -o $@ $(TESTUPNPPERMISSIONSOBJS)
++	$(CC) $(CFLAGS) -o $@ $(TESTUPNPPERMISSIONSOBJS) $(LIBS)
+ 
+ testgetroute:	config.h $(TESTGETROUTEOBJS)
+-	$(CC) $(CFLAGS) -o $@ $(TESTGETROUTEOBJS)
++	$(CC) $(CFLAGS) -o $@ $(TESTGETROUTEOBJS) $(LIBS)
+ 
+ # gmake :
+ #	$(CC) $(CFLAGS) -o $@ $^

--- a/net/miniupnpd/patches/patch-bsd_getroute.c
+++ b/net/miniupnpd/patches/patch-bsd_getroute.c
@@ -1,0 +1,23 @@
+$NetBSD$
+
+use the SA_LEN wrapper
+--- bsd/getroute.c.orig	2013-02-06 13:14:42.000000000 +0000
++++ bsd/getroute.c
+@@ -83,7 +83,7 @@ get_src_for_route_to(const struct sockad
+ 				sa = (struct sockaddr *)p;
+ 				sockaddr_to_string(sa, tmp, sizeof(tmp));
+ 				syslog(LOG_DEBUG, "type=%d sa_len=%d sa_family=%d %s",
+-				       i, sa->sa_len, sa->sa_family, tmp);
++				       i, SA_LEN(sa), sa->sa_family, tmp);
+ 				if((i == RTA_DST || i == RTA_GATEWAY) &&
+ 				   (src_len && src)) {
+ 					size_t len = 0;
+@@ -113,7 +113,7 @@ get_src_for_route_to(const struct sockad
+ 						*index = sdl->sdl_index;
+ 				}
+ #endif
+-				p += sa->sa_len;
++				p += SA_LEN(sa);
+ 			}
+ 		}
+ 	}

--- a/net/miniupnpd/patches/patch-bsd_ifacewatcher.c
+++ b/net/miniupnpd/patches/patch-bsd_ifacewatcher.c
@@ -1,0 +1,19 @@
+$NetBSD$
+
+use SA_LEN wrapper
+--- bsd/ifacewatcher.c.orig	2012-05-21 08:55:10.000000000 +0000
++++ bsd/ifacewatcher.c
+@@ -15,12 +15,8 @@
+ #include <syslog.h>
+ #include <signal.h>
+ 
+-#if !defined(SA_LEN)
+-#define	SA_LEN(sa)	(sa)->sa_len
+-#endif
+-
+ #define	SALIGN	(sizeof(long) - 1)
+-#define	SA_RLEN(sa)	((sa)->sa_len ? (((sa)->sa_len + SALIGN) & ~SALIGN) : (SALIGN + 1))
++#define	SA_RLEN(sa)	(SA_LEN(sa) ? ((SA_LEN(sa) + SALIGN) & ~SALIGN) : (SALIGN + 1))
+ 
+ #include "../upnputils.h"
+ #include "../upnpglobalvars.h"

--- a/net/miniupnpd/patches/patch-upnputils.h
+++ b/net/miniupnpd/patches/patch-upnputils.h
@@ -1,0 +1,34 @@
+$NetBSD$
+
+define SA_LEN wrapper and MAX macro if missing
+--- upnputils.h.orig	2013-02-06 10:51:05.000000000 +0000
++++ upnputils.h
+@@ -29,5 +29,28 @@ set_non_blocking(int fd);
+ struct lan_addr_s *
+ get_lan_for_peer(const struct sockaddr * peer);
+ 
++
++/**
++ * define portability macros
++ */
++#if defined(__sun)
++static size_t _sa_len(const struct sockaddr *addr)
++{
++        if (addr->sa_family == AF_INET)
++                return (sizeof(struct sockaddr_in));
++        else if (addr->sa_family == AF_INET6)
++                return (sizeof(struct sockaddr_in6));
++        else
++                return (sizeof(struct sockaddr));
++}
++# define SA_LEN(sa) (_sa_len(sa))
++#else
++# define SA_LEN(sa) ((sa)->sa_len)
++#endif
++
++#ifndef MAX
++# define MAX(a,b) (((a)>(b))?(a):(b))
++#endif
++
+ #endif
+ 


### PR DESCRIPTION
- update to 1.8 (20130730)
- some patches were needed to build on SmartOS
