### PR TITLE
Fix build on SmartOS, missing LDFLAG -lnsl

### DIFF
--- a/mail/rblcheck/Makefile
+++ b/mail/rblcheck/Makefile
@@ -19,6 +19,8 @@ DOCS=		README NEWS docs/rblcheck.ps
 
 AUTO_MKDIRS=	yes
 
+LDFLAGS.SunOS+=	-lnsl
+
 do-install:
 	${INSTALL_PROGRAM} ${WRKSRC}/rblcheck ${DESTDIR}${PREFIX}/bin
 	cd ${WRKSRC} &&						\


### PR DESCRIPTION
Add missing `LDFLAGS.SunOS+=  -lnsl` to build on SmartOS machines. Because of the `LICENSE` i'm not sure, it's missing but i couldn't find any matching file in the license folder.
