### PR TITLE
Fix dhcpd-pools for SmartOS, add missing LDFLAGS -lnsl

### DIFF
--- a/net/dhcpd-pools/Makefile
+++ b/net/dhcpd-pools/Makefile
@@ -19,6 +19,8 @@ BUILD_DEFS+=		VARBASE
 REPLACE_PERL=		contrib/snmptest.pl
 USE_TOOLS+=		perl:run
 
+LDFLAGS.SunOS+=	-lnsl
+
 SUBST_CLASSES+=		fix-name
 SUBST_STAGE.fix-name=	pre-configure
 SUBST_MESSAGE.fix-name=	Removing program_invocation_short_name.


### PR DESCRIPTION
Only add missing `-lnsl` to build `dhcpd-pools` on SmartOS.
