### PR TITLE
Fix hydra for SunOS only, because of missing LDFLAGS -lsocket -lnsl

### DIFF
--- a/security/hydra/Makefile
+++ b/security/hydra/Makefile
@@ -15,6 +15,8 @@ LICENSE=	gnu-agpl-v3
 USE_TOOLS+=	pkg-config gmake
 GNU_CONFIGURE=	YES
 
+LDFLAGS.SunOS+=	-lsocket -lnsl
+
 CONFIGURE_ENV+=	BUILDLINK_DIR=${BUILDLINK_DIR:Q}
 
 CONFIGURE_ARGS+=	--prefix=${PREFIX:Q}


### PR DESCRIPTION
Simple fix for the `hydra` package to build on SunOS. Add missing LDFLAGS `-lsocket -lnsl`
