### PR TITLE
Fix `suck` to build on SunOS as well, only modify the patch file

### DIFF
--- a/news/suck/patches/patch-ab
+++ b/news/suck/patches/patch-ab
@@ -6,7 +6,7 @@ $NetBSD: patch-ab,v 1.3 2006/10/15 21:59:13 schwarz Exp $
  void print_debug(PKillStruct, const char *);
  void debug_one_kill(POneKill);
  void add_to_linkedlist(pmy_regex *, pmy_regex);
-+#if !defined(__DragonFly__) && !defined(__APPLE__)
++#if !defined(__DragonFly__) && !defined(__APPLE__) && !defined(__sun)
  const char *strnstr(const char *, const char *);
 +#endif
  pmy_regex regex_scan(char *, char, int, int, char);


### PR DESCRIPTION
Simple modify the already existing patch for SunOS. SunOS also have `strnstr` implemented to do not add an additional `const` for it.
