### PR TITLE
sslproxy: update to 1.1.2, fix build on SmartOS

### DIFF
--- a/security/sslproxy/Makefile
+++ b/security/sslproxy/Makefile
@@ -1,20 +1,23 @@
 # $NetBSD: Makefile,v 1.4 2013/02/06 23:23:46 jperkin Exp $
 
-DISTNAME=	sslproxy-1.0.5
-PKGREVISION=	2
+DISTNAME=	sslproxy-1.1.2
 CATEGORIES=	net
-MASTER_SITES=	${MASTER_SITE_SOURCEFORGE:=sslproxy/}
+MASTER_SITES=	${MASTER_SITE_SOURCEFORGE:=sslproxy/1.1.2/}
 
 MAINTAINER=	pkgsrc-users@NetBSD.org
 HOMEPAGE=	http://sourceforge.net/projects/sslproxy/
 COMMENT=	Small SSL proxy
-
-EXTRACT_SUFX=		.tgz
+LICENSE=	gnu-gpl-v2
 
 USE_TOOLS+=		gmake
 
 DOCDIR=			${PREFIX}/share/doc/ssl_proxy
 INSTALLATION_DIRS=	bin ${DOCDIR}
+
+.include "../../mk/bsd.prefs.mk"
+.if ${OPSYS} == "SunOS"
+MAKE_ENV+=	LDLIBS="-lsocket -lnsl"
+.endif
 
 do-install:
 	${INSTALL_PROGRAM} ${WRKSRC}/ssl_proxy ${DESTDIR}${PREFIX}/bin/ssl_proxy

--- a/security/sslproxy/distinfo
+++ b/security/sslproxy/distinfo
@@ -1,5 +1,6 @@
 $NetBSD: distinfo,v 1.1.1.1 2008/12/05 12:52:39 sborrill Exp $
 
-SHA1 (sslproxy-1.0.5.tgz) = 539d9f8cffa4c65692523dd28688c5350c92b259
-RMD160 (sslproxy-1.0.5.tgz) = 300f7449bc1d8fbb20b0eb9b4aa22233a3f4179b
-Size (sslproxy-1.0.5.tgz) = 23756 bytes
+SHA1 (sslproxy-1.1.2.tar.gz) = 82cc27b28db4aeee04015d51aecc32bf635f6f18
+RMD160 (sslproxy-1.1.2.tar.gz) = 066f92751764f7f56ad57c4c05dab4ff940f07fa
+Size (sslproxy-1.1.2.tar.gz) = 25203 bytes
+SHA1 (patch-Makefile.global) = d1ab92900f52f6b10ae674862774d281d2dc82d7

--- a/security/sslproxy/patches/patch-Makefile.global
+++ b/security/sslproxy/patches/patch-Makefile.global
@@ -1,0 +1,13 @@
+$NetBSD$
+
+--- Makefile.global.orig	2009-02-27 14:03:08.000000000 +0000
++++ Makefile.global
+@@ -10,7 +10,6 @@ CC = gcc
+ LD = gcc
+ CINCLUDE =
+ CFLAGS = -Wall -g3 -DVERSION=\"$(VERSION)\"
+-LDFLAGS =
+ COPTS = $(CFLAGS) $(CINCLUDE) $(CCPRAGMA)
+-LDLIBS = -lssl -lcrypto
++LDLIBS += -lssl -lcrypto
+ LDOPTS = $(LDFLAGS) $(LDLIBS)


### PR DESCRIPTION
- update to 1.1.2
- fix build on SmartOS
