### PR TITLE
Fix x2vnc to build on SunOS and add LICENSE information

### DIFF
--- a/net/x2vnc/Makefile
+++ b/net/x2vnc/Makefile
@@ -1,17 +1,18 @@
-# $NetBSD: Makefile,v 1.20 2012/10/23 17:19:20 asau Exp $
+# $NetBSD: Makefile,v 1.22 2013/10/24 18:28:00 tm Exp $
 #
 
 DISTNAME=		x2vnc-1.7.2
-PKGREVISION=		1
+PKGREVISION=		2
 CATEGORIES=		net x11
 MASTER_SITES=		http://fredrik.hubbe.net/x2vnc/
 
 MAINTAINER=		pkgsrc-users@NetBSD.org
 HOMEPAGE=		http://fredrik.hubbe.net/x2vnc.html
 COMMENT=		Multi-console display using X and VNC
+LICENSE=		gnu-gpl-v2
 
 GNU_CONFIGURE=		yes
-LDFLAGS.SunOS+=		-lresolv
+LDFLAGS.SunOS+=		-lresolv -lsocket
 
 .include "options.mk"
 


### PR DESCRIPTION
Build failed because of missing `LDFLAGS -lsocket`. I've also added the LICENSE information.
