### PR TITLE
Fix mod_dav_subversion for apache to build on SmartOS

### DIFF
--- a/www/ap2-subversion/Makefile
+++ b/www/ap2-subversion/Makefile
@@ -14,6 +14,8 @@ APACHE_MODULE=		YES
 BUILD_TARGET=		apache-mod
 INSTALL_TARGET=		install-mods-shared
 
+CFLAGS.SunOS+=	-D__EXTENSIONS__
+
 post-patch:
 	${RM} ${WRKSRC}/build-outputs.mk
 	${CP} ${FILESDIR}/build-outputs.mk ${WRKSRC}/build-outputs.mk


### PR DESCRIPTION
The `__EXTENSIONS__` is required to build on Solaris / SmartOS. It's the same as for the `subversion-base` package.
