### PR TITLE
sysutils/apcupsd: add missing buildlink for libusb

### DIFF
--- a/sysutils/apcupsd/Makefile
+++ b/sysutils/apcupsd/Makefile
@@ -116,4 +116,5 @@ post-install:
 .endfor
 
 .include "../../devel/gettext-lib/buildlink3.mk"
+.include "../../devel/libusb/buildlink3.mk"
 .include "../../mk/bsd.pkg.mk"


### PR DESCRIPTION
buildlink for libusb was missing
