### PR TITLE
emulators/xm7: fix build on SmartOS

### DIFF
--- a/emulators/xm7/distinfo
+++ b/emulators/xm7/distinfo
@@ -6,5 +6,5 @@ Size (xm71020s.zip) = 289896 bytes
 SHA1 (patch-aa) = b49f4dac3dde6395fcf1d4ab0c987d577e5e9ce4
 SHA1 (patch-ab) = 4e6cc9113e25eca32a1f672b82b3c07ed141a5b7
 SHA1 (patch-ac) = 5a2dd19976d117651860d7ee5b83afe762050001
-SHA1 (patch-ad) = d92ce48806c57a8cf0447f3e647202709e9a63d3
+SHA1 (patch-ad) = 3876e0dfc3ad8aecdfb0c1c4443131fa60af36d1
 SHA1 (patch-ae) = ee3a92da9301db4aca1b9eff7b4850f17334345c

--- a/emulators/xm7/patches/patch-ad
+++ b/emulators/xm7/patches/patch-ad
@@ -1,14 +1,22 @@
 $NetBSD: patch-ad,v 1.2 2006/01/12 21:05:19 joerg Exp $
 
---- xw_snd.cpp.orig	2000-03-22 16:01:00.000000000 +0000
+--- xw_snd.cpp.orig	2001-03-22 16:02:00.000000000 +0000
 +++ xw_snd.cpp
-@@ -22,8 +22,10 @@
+@@ -8,6 +8,7 @@
+ #include <assert.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include "xm7.h"
+ #include "opn.h"
+ #include "device.h"
+@@ -22,8 +23,10 @@
  #include <fcntl.h>
  #include <sys/ioctl.h>
  #include <sys/time.h>
 -#ifdef __FreeBSD__
 -#include <machine/soundcard.h>
-+#if defined(__FreeBSD__) || defined(__DragonFly__)
++#if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__sun)
 +#include <sys/soundcard.h>
 +#elif defined(__NetBSD__) || defined(__OpenBSD__)
 +#include <soundcard.h>


### PR DESCRIPTION
fix include of <code>soundcard.h</code> on SunOS and missing <code>strings.h</code>
