### PR TITLE
httping: fix build on SmartOS

### DIFF
--- a/net/httping/Makefile
+++ b/net/httping/Makefile
@@ -1,7 +1,7 @@
 # $NetBSD: Makefile,v 1.19 2014/02/12 23:18:20 tron Exp $
 
 DISTNAME=	httping-2.3.3
-PKGREVISION=	1
+PKGREVISION=	2
 CATEGORIES=	net
 MASTER_SITES=	http://www.vanheusden.com/httping/
 EXTRACT_SUFX=	.tgz
@@ -19,7 +19,7 @@ CONFIGURE_ARGS+=	--with-openssl
 .include "../../mk/bsd.prefs.mk"
 
 LDFLAGS.NetBSD=		-lintl
-LDFLAGS.SunOS=		-lnsl -lsocket
+LDFLAGS.SunOS=		-lnsl -lsocket -lresolv -lintl
 
 .include "../../devel/gettext-lib/buildlink3.mk"
 .include "../../security/openssl/buildlink3.mk"

--- a/net/httping/distinfo
+++ b/net/httping/distinfo
@@ -4,3 +4,4 @@ SHA1 (httping-2.3.3.tgz) = 6b9e77039346388e2b02dbb1d60f7422e7133488
 RMD160 (httping-2.3.3.tgz) = 204a9ddff58086434c1f5c608a0f5360747fb9bb
 Size (httping-2.3.3.tgz) = 54376 bytes
 SHA1 (patch-aa) = 72c327379b1cbe3cae7436e09ccee53f9277652d
+SHA1 (patch-main.cc) = 4641021cee9ce61642ff0d836aba151d1f0c8d1c

--- a/net/httping/patches/patch-main.cc
+++ b/net/httping/patches/patch-main.cc
@@ -1,0 +1,17 @@
+$NetBSD$
+
+TIOCOUTQ is defined in termios.h on SunOS and required by ioctl().
+
+--- main.c.orig	2013-06-07 13:18:52.000000000 +0000
++++ main.c
+@@ -45,6 +45,10 @@
+ #endif
+ #include "cookies.h"
+ 
++#ifdef __sun
++#include <sys/termios.h>
++#endif
++
+ volatile int stop = 0;
+ 
+ int quiet = 0;


### PR DESCRIPTION
`TIOCOUTQ` is defined in `termios.h` on SunOS and required by ioctl()
