### PR TITLE
make libmilter get built with PIC

### DIFF
--- a/mail/sendmail/distinfo
+++ b/mail/sendmail/distinfo
@@ -16,3 +16,4 @@ SHA1 (patch-aj) = e65e6fe44380de2f9c397c1a97677eb4ad285433
 SHA1 (patch-al) = f5d8cef8c4abba5d5ae813b754c16037190a7ef1
 SHA1 (patch-am) = d84eedbff0f037c1db341255dc9e1877866f12c7
 SHA1 (patch-an) = 82d2df0c609099f295eb00f1f5e19391ae97833c
+SHA1 (patch-libmilter_Makefile.m4) = 8a37b839a42081189267a5c39a9457bff68cc0c2

--- a/mail/sendmail/patches/patch-libmilter_Makefile.m4
+++ b/mail/sendmail/patches/patch-libmilter_Makefile.m4
@@ -1,0 +1,12 @@
+$NetBSD$
+
+--- libmilter/Makefile.m4.orig	2013-04-16 20:19:54.000000000 +0000
++++ libmilter/Makefile.m4
+@@ -10,6 +10,7 @@ SMSRCDIR=ifdef(`confSMSRCDIR', `confSMSR
+ PREPENDDEF(`confINCDIRS', `-I${SMSRCDIR} ')
+ 
+ bldPRODUCT_START(`library', `libmilter')
++APPENDDEF(`confOPTIMIZE', `-fPIC')
+ define(`bldINSTALLABLE', `true')
+ define(`LIBMILTER_EXTRAS', `errstring.c strl.c')
+ APPENDDEF(`confENVDEF', `-DNOT_SENDMAIL -Dsm_snprintf=snprintf')


### PR DESCRIPTION
this fixes an issue with installing pymilter
which couldn't link the libmilter.a object

steps to reproduce:
  virtualenv pymilter-test
  cd pymilter-test/
  . bin/activate
  pip install pymilter
