### PR TITLE
Updating for Mailman 2.1.18-1

### DIFF
--- a/mail/mailman/Makefile
+++ b/mail/mailman/Makefile
@@ -1,10 +1,10 @@
 # $NetBSD: Makefile,v 1.69 2014/01/25 10:45:19 wiz Exp $
 
-DISTNAME=	mailman-2.1.14-1
-PKGNAME=	mailman-2.1.14.1
-PKGREVISION=	4
+DISTNAME=	mailman-2.1.18-1
+PKGNAME=	mailman-2.1.18.1
+PKGREVISION=	0
 CATEGORIES=	mail www
-MASTER_SITES=	http://launchpad.net/mailman/2.1/2.1.14/+download/
+MASTER_SITES=	http://launchpad.net/mailman/2.1/2.1.18-1/+download/
 EXTRACT_SUFX=	.tgz
 
 MAINTAINER=	pkgsrc-users@NetBSD.org

--- a/mail/mailman/PLIST
+++ b/mail/mailman/PLIST
@@ -205,6 +205,8 @@ lib/mailman/Mailman/Handlers/ToOutgoing.py
 lib/mailman/Mailman/Handlers/ToOutgoing.pyc
 lib/mailman/Mailman/Handlers/ToUsenet.py
 lib/mailman/Mailman/Handlers/ToUsenet.pyc
+lib/mailman/Mailman/Handlers/WrapMessage.py
+lib/mailman/Mailman/Handlers/WrapMessage.pyc
 lib/mailman/Mailman/Handlers/__init__.py
 lib/mailman/Mailman/Handlers/__init__.pyc
 lib/mailman/Mailman/ListAdmin.py

--- a/mail/mailman/PLIST
+++ b/mail/mailman/PLIST
@@ -53,6 +53,8 @@ lib/mailman/Mailman/Bouncers/Yale.py
 lib/mailman/Mailman/Bouncers/Yale.pyc
 lib/mailman/Mailman/Bouncers/__init__.py
 lib/mailman/Mailman/Bouncers/__init__.pyc
+lib/mailman/Mailman/CSRFcheck.py
+lib/mailman/Mailman/CSRFcheck.pyc
 lib/mailman/Mailman/Cgi/Auth.py
 lib/mailman/Mailman/Cgi/Auth.pyc
 lib/mailman/Mailman/Cgi/__init__.py

--- a/mail/mailman/distinfo
+++ b/mail/mailman/distinfo
@@ -1,8 +1,8 @@
 $NetBSD: distinfo,v 1.21 2011/12/22 11:06:40 fhajny Exp $
 
-SHA1 (mailman-2.1.14-1.tgz) = 390874c1059878b33be9ab4cf57fdb719eac1819
-RMD160 (mailman-2.1.14-1.tgz) = 0d86e766e28aaab9703bfe530b72316a5b02beda
-Size (mailman-2.1.14-1.tgz) = 8201308 bytes
+SHA1 (mailman-2.1.18-1.tgz) = 1e1ac7288d679c7fb8e871a7585c7aafaacd1d6c
+RMD160 (mailman-2.1.18-1.tgz) = 438d319858a89f61032b96201d39d6b2a1968c14
+Size (mailman-2.1.18-1.tgz) = 9095511 bytes
 SHA1 (patch-aa) = 9684b1caeb52f31ee6967eae3f9a464de214879e
 SHA1 (patch-ab) = 39f6294e53110bd1fd09b1e90ab46820f4d48e3f
 SHA1 (patch-ad) = 665884b9dd1789e4abd430c762bdbfd707d48d30


### PR DESCRIPTION
WIP for the DMARC issues with Mailman prior to 2.1.18-1 with bouncing emails from @yahoo.com and @aol.com users.
