### PR TITLE
Set PATH environment variable for PostgreSQL server in smf manifest.

### DIFF
--- a/databases/postgresql90-server/files/smf/manifest.xml
+++ b/databases/postgresql90-server/files/smf/manifest.xml
@@ -14,6 +14,7 @@
       <method_credential user='@PGUSER@' group='@PGGROUP@' />
       <method_environment>
         <envvar name="LD_PRELOAD_32" value="/usr/lib/extendedFILE.so.1" />
+        <envvar name='PATH' value='@PREFIX@/bin:@PREFIX@/sbin:/usr/bin:/usr/sbin:/bin:/sbin'/>
       </method_environment>
     </method_context>
     <exec_method type='method' name='start' exec='@PREFIX@/@SMF_METHOD_FILE.postgresql@ start' timeout_seconds='300' />

--- a/databases/postgresql91-server/files/smf/manifest.xml
+++ b/databases/postgresql91-server/files/smf/manifest.xml
@@ -14,6 +14,7 @@
       <method_credential user='@PGUSER@' group='@PGGROUP@' />
       <method_environment>
         <envvar name="LD_PRELOAD_32" value="/usr/lib/extendedFILE.so.1" />
+        <envvar name='PATH' value='@PREFIX@/bin:@PREFIX@/sbin:/usr/bin:/usr/sbin:/bin:/sbin'/>
       </method_environment>
     </method_context>
     <exec_method type='method' name='start' exec='@PREFIX@/@SMF_METHOD_FILE.postgresql@ start' timeout_seconds='300' />

--- a/databases/postgresql92-server/files/smf/manifest.xml
+++ b/databases/postgresql92-server/files/smf/manifest.xml
@@ -14,6 +14,7 @@
       <method_credential user='@PGUSER@' group='@PGGROUP@' />
       <method_environment>
         <envvar name="LD_PRELOAD_32" value="/usr/lib/extendedFILE.so.1" />
+        <envvar name='PATH' value='@PREFIX@/bin:@PREFIX@/sbin:/usr/bin:/usr/sbin:/bin:/sbin'/>
       </method_environment>
     </method_context>
     <exec_method type='method' name='start' exec='@PREFIX@/@SMF_METHOD_FILE.postgresql@ start' timeout_seconds='300' />

--- a/databases/postgresql93-server/files/smf/manifest.xml
+++ b/databases/postgresql93-server/files/smf/manifest.xml
@@ -14,6 +14,7 @@
       <method_credential user='@PGUSER@' group='@PGGROUP@' />
       <method_environment>
         <envvar name="LD_PRELOAD_32" value="/usr/lib/extendedFILE.so.1" />
+        <envvar name='PATH' value='@PREFIX@/bin:@PREFIX@/sbin:/usr/bin:/usr/sbin:/bin:/sbin'/>
       </method_environment>
     </method_context>
     <exec_method type='method' name='start' exec='@PREFIX@/@SMF_METHOD_FILE.postgresql@ start' timeout_seconds='300' />


### PR DESCRIPTION
I have some PL/Perl modules (HTML::HTMLDoc is one of them) that don't work on SmartOS.
Problem is that module calls htmldoc binary (located in /opt/local/bin) and to find it we have to set the PATH variable in the SMF manifest. Would this be desirable for other SMF manifests?
