### PR TITLE
Fix www/wml configure to always use posix mode

### DIFF
--- a/www/wml/distinfo
+++ b/www/wml/distinfo
@@ -16,6 +16,7 @@ SHA1 (patch-ak) = 3b81025819f259d7ebb185de4d4890c9892aba87
 SHA1 (patch-al) = 9bdf732aad8520b89bc5925ae6eb0e2cce937f6b
 SHA1 (patch-am) = 5e597fed00ee56fbaf54d6725e36f9c9e5292c0e
 SHA1 (patch-wml__aux_freetable_freetable.src) = 938f2b380147476a8e959e15ccf6e2887191448d
+SHA1 (patch-wml__backend_p2__mp4h_configure) = c13341a29edfae929bf930ae7b8ed337b5c04d4b
 SHA1 (patch-wml__backend_p2__mp4h_doc_mp4h.mp4h) = 3ab650e57012ad85f89156fdd639df0c695c21af
 SHA1 (patch-wml__backend_p3__eperl_eperl__perl5.c) = e80878ccdd6d58efa42b987b3951897c1c8df32b
 SHA1 (patch-wml__backend_p3__eperl_eperl__perl5.h) = 0e4534ce4171472b5c26eb9def7dfa4067bc6fe8

--- a/www/wml/patches/patch-wml__backend_p2__mp4h_configure
+++ b/www/wml/patches/patch-wml__backend_p2__mp4h_configure
@@ -1,0 +1,19 @@
+$NetBSD$
+
+This ensures the current shell is in posix compatibility mode. Modern
+versions of autoconf can do this now, but this configure script has
+not been regenerated in a long time...
+
+--- wml_backend/p2_mp4h/configure.orig	2006-08-19 06:09:49.000000000 +0000
++++ wml_backend/p2_mp4h/configure
+@@ -16,8 +16,8 @@ if test -n "${ZSH_VERSION+set}" && (emul
+   # Zsh 3.x and 4.x performs word splitting on ${1+"$@"}, which
+   # is contrary to our usage.  Disable this feature.
+   alias -g '${1+"$@"}'='"$@"'
+-elif test -n "${BASH_VERSION+set}" && (set -o posix) >/dev/null 2>&1; then
+-  set -o posix
++else
++  case `(set -o) 2>/dev/null` in *posix*) set -o posix;; esac
+ fi
+ DUALCASE=1; export DUALCASE # for MKS sh
+ 


### PR DESCRIPTION
Because wml uses very old configure scripts, the posix mode
is not set with all shells. This can cause a test in the script
to be false and makes it re-exec itself indefinitely.
