### PR TITLE
write_riemann plugin for collectd

### DIFF
--- a/sysutils/collectd-riemann/DESCR
+++ b/sysutils/collectd-riemann/DESCR
@@ -1,0 +1,1 @@
+riemann output plugin for collectd

--- a/sysutils/collectd-riemann/Makefile
+++ b/sysutils/collectd-riemann/Makefile
@@ -1,0 +1,13 @@
+# $NetBSD$
+
+COLLECTD_PACKAGE=       riemann
+COLLECTD_PLUGINS=       write_riemann
+
+COMMENT=                Statistics collection daemon - riemann plugin
+
+.include "../../sysutils/collectd/Makefile.common"
+
+#CONFIGURE_ARGS+=       --enable-write-riemann
+
+.include "../../wip/protobuf-c/buildlink3.mk"
+.include "../../mk/bsd.pkg.mk"


### PR DESCRIPTION
This package add the write_riemann plugin to collectd. It uses protobuf-c.
I pretty much copied the collectd-amqp package.

My first pull request and package ever so let me know if something is missing.
