### PR TITLE
Add http2 support to Curl

### DIFF
--- a/mk/defaults/options.description
+++ b/mk/defaults/options.description
@@ -265,6 +265,7 @@ halfops			Halfops are similar to plain ops, but can't kick/deop plain ops.
 hawknl			Enable HawkNL network API support.
 hping-suid		Install hping executable setuid root.
 hpn-patch		High Performance Enabled SSH/SCP for OpenSSH.
+http2			Enable support for HTTP/2
 hunspell		Add spell checking support using hunspell.
 i586-optimized		Optimize for i586 (only).
 ibus			Enable Intelligent Input Bus support.

--- a/www/curl/Makefile
+++ b/www/curl/Makefile
@@ -21,7 +21,6 @@ GNU_CONFIGURE=		yes
 CONFIGURE_ARGS+=	--with-ssl=${BUILDLINK_PREFIX.openssl}
 CONFIGURE_ARGS+=	--with-ca-path=${SSLCERTS}
 CONFIGURE_ARGS+=	--with-zlib=${BUILDLINK_PREFIX.zlib}
-CONFIGURE_ARGS+=	--with-nghttp2=${BUILDLINK_PREFIX.nghttp2}
 PKGCONFIG_OVERRIDE=	libcurl.pc.in
 
 INSTALLATION_DIRS=	share/doc/curl
@@ -46,5 +45,4 @@ post-install:
 
 .include "../../devel/zlib/buildlink3.mk"
 .include "../../security/openssl/buildlink3.mk"
-.include "../../www/nghttp2/buildlink3.mk"
 .include "../../mk/bsd.pkg.mk"

--- a/www/curl/Makefile
+++ b/www/curl/Makefile
@@ -21,6 +21,7 @@ GNU_CONFIGURE=		yes
 CONFIGURE_ARGS+=	--with-ssl=${BUILDLINK_PREFIX.openssl}
 CONFIGURE_ARGS+=	--with-ca-path=${SSLCERTS}
 CONFIGURE_ARGS+=	--with-zlib=${BUILDLINK_PREFIX.zlib}
+CONFIGURE_ARGS+=	--with-nghttp2=${BUILDLINK_PREFIX.nghttp2}
 PKGCONFIG_OVERRIDE=	libcurl.pc.in
 
 INSTALLATION_DIRS=	share/doc/curl
@@ -45,4 +46,5 @@ post-install:
 
 .include "../../devel/zlib/buildlink3.mk"
 .include "../../security/openssl/buildlink3.mk"
+.include "../../www/nghttp2/buildlink3.mk"
 .include "../../mk/bsd.pkg.mk"

--- a/www/curl/options.mk
+++ b/www/curl/options.mk
@@ -1,7 +1,7 @@
 # $NetBSD: options.mk,v 1.12 2015/01/08 19:23:53 wiz Exp $
 
 PKG_OPTIONS_VAR=	PKG_OPTIONS.curl
-PKG_SUPPORTED_OPTIONS=	inet6 libssh2 gssapi ldap rtmp libidn
+PKG_SUPPORTED_OPTIONS=	inet6 libssh2 gssapi ldap rtmp libidn http2
 PKG_SUGGESTED_OPTIONS=	inet6 libidn
 
 .include "../../mk/bsd.prefs.mk"
@@ -54,3 +54,11 @@ CONFIGURE_ARGS+=	--with-libidn
 .else
 CONFIGURE_ARGS+=	--without-libidn
 .endif
+
+.if !empty(PKG_OPTIONS:Mhttp2)
+.include "../../www/nghttp2/buildlink3.mk"
+CONFIGURE_ARGS+=	--with-nghttp2=${BUILDLINK_PREFIX.nghttp2}
+.else
+CONFIGURE_ARGS+=	--without-nghttp2
+.endif
+

--- a/www/nghttp2/DESCR
+++ b/www/nghttp2/DESCR
@@ -1,0 +1,1 @@
+nghttp2 is an implementation of HTTP/2 in C. HTTP/2 and HPACK has been approved by IETF, we are now waiting for their publication as RFCs. Check out http://datatracker.ietf.org/doc/draft-ietf-httpbis-http2/ to track its progress.

--- a/www/nghttp2/Makefile
+++ b/www/nghttp2/Makefile
@@ -1,0 +1,42 @@
+# $NetBSD$
+
+DISTNAME=	nghttp2-0.7.12
+CATEGORIES=	www
+MASTER_SITES=	https://github.com/tatsuhiro-t/nghttp2/releases/download/v${PKGVERSION_NOREV}/
+EXTRACT_SUFX=	.tar.bz2
+
+MAINTAINER=	pkgsrc-users@NetBSD.org
+HOMEPAGE=	https://nghttp2.org/
+COMMENT=	nghttp2 is an implementation of HTTP/2 in C
+LICENSE=	mit
+
+GNU_CONFIGURE=	yes
+USE_LIBTOOL=	yes
+USE_TOOLS+=	pkg-config
+USE_LANGUAGES=	c c++
+
+#OPENSSL_CFLAGS+=	-I${BUILDLINK_PREFIX.openssl}/include
+#OPENSSL_LIBS+=		-L${BUILDLINK_PREFIX.openssl}/lib \
+			#-W,-lR${BUILDLINK_PREFIX.openssl}/lib
+#MAKE_ENV+=		ZLIB_LIBS=${BUILDLINK_PREFIX.zlib}/lib
+#CONFIGURE_ENV+=		OPENSSL_CFLAGS=${OPENSSL_CFLAGS:Q}
+#CONFIGURE_ENV+=		OPENSSL_LIBS=${OPENSSL_LIBS:Q}
+
+#CONFIGURE_ARGS+=	--enable-app
+#CONFIGURE_ARGS+=	--enable-examples
+#CONFIGURE_ARGS+=        --with-spdylay=${BUILDLINK_PREFIX.spdylay}
+CONFIGURE_ARGS+=	--enable-boost=${BUILDLINK_PREFIX.boost-libs}
+CONFIGURE_ARGS+=        --with-openssl=${BUILDLINK_PREFIX.openssl}
+CONFIGURE_ARGS+=        --with-libxml2=${BUILDLINK_PREFIX.libxml2}
+
+PKGCONFIG_OVERRIDE+=	lib/libnghttp2.pc.in
+PKGCONFIG_OVERRIDE+=	src/libnghttp2_asio.pc.in
+
+.include "../../devel/boost-libs/buildlink3.mk"
+#.include "../../devel/libev/buildlink3.mk"
+#.include "../../devel/libevent/buildlink3.mk"
+#.include "../../devel/zlib/buildlink3.mk"
+.include "../../security/openssl/buildlink3.mk"
+.include "../../textproc/libxml2/buildlink3.mk"
+#.include "../../www/spdylay/buildlink3.mk"
+.include "../../mk/bsd.pkg.mk"

--- a/www/nghttp2/PLIST
+++ b/www/nghttp2/PLIST
@@ -1,0 +1,11 @@
+@comment $NetBSD$
+include/nghttp2/nghttp2.h
+include/nghttp2/nghttp2ver.h
+lib/libnghttp2.la
+lib/pkgconfig/libnghttp2.pc
+man/man1/h2load.1
+man/man1/nghttp.1
+man/man1/nghttpd.1
+man/man1/nghttpx.1
+share/doc/nghttp2/README.rst
+share/nghttp2/fetch-ocsp-response

--- a/www/nghttp2/buildlink3.mk
+++ b/www/nghttp2/buildlink3.mk
@@ -1,0 +1,13 @@
+# $NetBSD$
+
+BUILDLINK_TREE+=	nghttp2
+
+.if !defined(NGHTTP2_BUILDLINK3_MK)
+NGHTTP2_BUILDLINK3_MK:=
+
+BUILDLINK_API_DEPENDS.nghttp2+=	nghttp2>=0.7.12
+BUILDLINK_ABI_DEPENDS.nghttp2+=	nghttp2>=0.7.12
+BUILDLINK_PKGSRCDIR.nghttp2?=	../../www/nghttp2
+.endif # NGHTTP2_BUILDLINK3_MK
+
+BUILDLINK_TREE+=	-nghttp2

--- a/www/nghttp2/distinfo
+++ b/www/nghttp2/distinfo
@@ -1,0 +1,5 @@
+$NetBSD$
+
+SHA1 (nghttp2-0.7.12.tar.bz2) = 277ba37901a8ffb5b5ae077115060e424fdf1cd4
+RMD160 (nghttp2-0.7.12.tar.bz2) = 19d1e758acdc9a0f159c6232b81daff82a7e490e
+Size (nghttp2-0.7.12.tar.bz2) = 1105175 bytes


### PR DESCRIPTION
Also contains placeholders for enabling test apps from the nghttp2 package by adding spdylay support (not yet working).
