### PR TITLE
Added SMF support to 'sysutils/salt'.

### DIFF
--- a/sysutils/salt/Makefile
+++ b/sysutils/salt/Makefile
@@ -36,6 +36,7 @@ PYSETUPINSTALLARGS+=	--salt-pidfile-dir=${VARBASE}/run
 REPLACE_PYTHON=	*.py */*.py */*/*.py
 
 RCD_SCRIPTS+=		salt_master salt_minion
+SMF_INSTANCES+=		master minion
 FILES_SUBST+=		PYTHON=${PYTHONBIN:Q}
 
 PKG_SYSCONFSUBDIR=	salt

--- a/sysutils/salt/files/smf/manifest.xml
+++ b/sysutils/salt/files/smf/manifest.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="@SMF_NAME@">
+<service name="@SMF_PREFIX@/@SMF_NAME@" type="service" version="1">
+	<dependency name='network' grouping='require_all' restart_on='error' type='service'>
+		<service_fmri value='svc:/milestone/network:default' />
+	</dependency>
+	<dependency name='filesystem-local' grouping='require_all' restart_on='none' type='service'>
+		<service_fmri value='svc:/system/filesystem/local:default' />
+	</dependency>
+
+	<method_context>
+		<method_credential user='root' group='root' />
+		<method_environment>
+			<envvar name="LD_PRELOAD_32" value="/usr/lib/extendedFILE.so.1" />
+		</method_environment>
+	</method_context>
+	
+	<instance name='master' enabled='false'>
+		<exec_method type="method" name="start" exec="@PREFIX@/bin/salt-master -d" timeout_seconds="60" />
+		<exec_method type="method" name="stop" exec=":kill" timeout_seconds="60" />
+		<exec_method type="method" name="refresh" exec=":kill -HUP" timeout_seconds="60" />
+		<property_group name="startd" type="framework">
+			<propval name="duration" type="astring" value="contract" />
+			<propval name="ignore_error" type="astring" value="core,signal" />
+		</property_group>
+		<property_group name="application" type="application">
+			<propval name="config_file" type="astring" value="@PKG_SYSCONFDIR@/salt/master" />
+		</property_group>
+		<template>
+			<common_name>
+				<loctext xml:lang='C'>Salt Master daemon</loctext>
+			</common_name>
+			<documentation>
+				<manpage title='salt-master' section='1' manpath='man'/>
+			</documentation>
+		</template>
+	</instance>
+
+	<instance name='minion' enabled='false'>
+		<exec_method type="method" name="start" exec="@PREFIX@/bin/salt-minion -d" timeout_seconds="60" />
+		<exec_method type="method" name="stop" exec=":kill" timeout_seconds="60" />
+		<exec_method type="method" name="refresh" exec=":kill -HUP" timeout_seconds="60" />
+		<property_group name="startd" type="framework">
+			<propval name="duration" type="astring" value="contract" />
+			<propval name="ignore_error" type="astring" value="core,signal" />
+		</property_group>
+		<property_group name="application" type="application">
+			<propval name="config_file" type="astring" value="@PKG_SYSCONFDIR@/salt/minion" />
+		</property_group>
+		<template>
+			<common_name>
+				<loctext xml:lang='C'>Salt Minion daemon</loctext>
+			</common_name>
+			<documentation>
+				<manpage title='salt-minion' section='1' manpath='man'/>
+			</documentation>
+		</template>
+	</instance>
+	
+	<stability value="Unstable" />
+</service>
+</service_bundle>


### PR DESCRIPTION
I've added an SMF manifest to the SaltStack package for use with systems that support SMF. From what I could see pkgsrc currently does not support using multiple SMF manifests in a single package. Therefor i've solved the 'problem' of multiple services in a single package the same way as in the Samba package by using instances.
