### PR TITLE
Fix UnrealIRCD IPv6 build; add SMF support.

### DIFF
--- a/chat/unrealircd/Makefile
+++ b/chat/unrealircd/Makefile
@@ -1,6 +1,6 @@
 # $NetBSD: Makefile,v 1.43 2015/11/07 22:52:04 dholland Exp $
 
-DISTNAME=	Unreal3.2.10.4
+DISTNAME=	Unreal3.2.10.5
 PKGNAME=	${DISTNAME:tl:S/l/lircd-/1}
 PKGREVISION=	1
 CATEGORIES=	chat

--- a/chat/unrealircd/distinfo
+++ b/chat/unrealircd/distinfo
@@ -1,9 +1,9 @@
 $NetBSD: distinfo,v 1.18 2015/11/07 22:52:54 dholland Exp $
 
-SHA1 (Unreal3.2.10.4.tar.gz) = fa2b828b98afeab8677cb04aed9a634f7e43c386
-RMD160 (Unreal3.2.10.4.tar.gz) = 07c4854a59432dfa8a2ef16c5c9517e08b20cb6b
-SHA512 (Unreal3.2.10.4.tar.gz) = eeecefe79cadf3efa1b9379d4b675c0b86a2dd91e703f9e4b3998331f56b923d3719c67482f464f9b1699f801e0a83d677ada642ea7037c52a9d5db63abe6a5c
-Size (Unreal3.2.10.4.tar.gz) = 3540227 bytes
+SHA1 (Unreal3.2.10.5.tar.gz) = 3a8823e79c8c89ac8339e105c6c0b6a2a76f6097
+RMD160 (Unreal3.2.10.5.tar.gz) = 4acf7edbadeca5679a22a09d16e08873f1e61e8b
+SHA512 (Unreal3.2.10.5.tar.gz) = 98c71a958f3b620ff4c9d83279c508e13bdd76cc9d191ac021c4ef57eaf6a549345c0b2c1f8c550f29c2d79f8f257a176ae73e73dcbab839715462aa4b80565e
+Size (Unreal3.2.10.5.tar.gz) = 3538121 bytes
 SHA1 (patch-ab) = b66ae1990e25479abe9087a9308a2185692fcba2
 SHA1 (patch-ac) = 7b2909bc4c9676440d752675a42115c3b3fc3a1c
 SHA1 (patch-ae) = ec6baaa921a9ee9cf8e494da4185b22697299545

--- a/chat/unrealircd/files/smf/manifest.xml
+++ b/chat/unrealircd/files/smf/manifest.xml
@@ -11,7 +11,7 @@
       <service_fmri value='svc:/system/filesystem/local:default' />
     </dependency>
     <method_context>
-      <method_credential user='uircd' group='uircd' />
+      <method_credential user='@UIRCD_USER@' group='@UIRCD_GROUP@' />
     </method_context>
     <exec_method type="method" name="start" exec="@PREFIX@/sbin/ircd -f %{config_file} -F" timeout_seconds="60" />
     <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60" />

--- a/chat/unrealircd/files/smf/manifest.xml
+++ b/chat/unrealircd/files/smf/manifest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="@SMF_NAME@">
+  <service name="@SMF_PREFIX@/@SMF_NAME@" type="service" version="1">
+    <create_default_instance enabled="false" />
+    <single_instance />
+    <dependency name='network' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/milestone/network:default' />
+    </dependency>
+    <dependency name='filesystem-local' grouping='require_all' restart_on='none' type='service'>
+      <service_fmri value='svc:/system/filesystem/local:default' />
+    </dependency>
+    <method_context>
+      <method_credential user='uircd' group='uircd' />
+    </method_context>
+    <exec_method type="method" name="start" exec="@PREFIX@/sbin/ircd -f %{config_file} -F" timeout_seconds="60" />
+    <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60" />
+    <exec_method type="method" name="refresh" exec=":kill -HUP" timeout_seconds="60" />
+    <property_group name="startd" type="framework">
+      <propval name="duration" type="astring" value="child" />
+      <propval name="ignore_error" type="astring" value="core,signal" />
+    </property_group>
+    <property_group name="application" type="application">
+      <propval name="config_file" type="astring" value="@UIRCD_HOME@/unrealircd.conf" />
+    </property_group>
+    <stability value="Evolving" />
+    <template>
+      <common_name>
+        <loctext xml:lang="C">UnrealIRCD IRC server</loctext>
+      </common_name>
+    </template>
+  </service>
+</service_bundle>

--- a/chat/unrealircd/options.mk
+++ b/chat/unrealircd/options.mk
@@ -17,7 +17,7 @@ PKG_SUGGESTED_OPTIONS=	unrealircd-showlistmodes unrealircd-prefixaq
 ###
 .if !empty(PKG_OPTIONS:Minet6)
 CONFIGURE_ARGS+=	--enable-inet6
-MESSAGE_SRC+=		MESSAGE_SRC.inet6
+MESSAGE_SRC+=		MESSAGE.inet6
 .else
 CONFIGURE_ARGS+=	--disable-inet6
 CONFIGURE_ENV+=		ac_cv_ip6=no
@@ -43,7 +43,7 @@ CONFIGURE_ARGS+=	--enable-nospoof
 ### server <-> server with zlib.
 ###
 .if !empty(PKG_OPTIONS:Munrealircd-ziplinks)
-CONFIGURE_ARGS+=		--enable-ziplinks
+CONFIGURE_ARGS+=		--enable-ziplinks=${BUILDLINK_PREFIX.zlib}
 .	include "../../devel/zlib/buildlink3.mk"
 .endif
 


### PR DESCRIPTION
Hi,

The build for UnrealIRCd is broken because of a wrong filename. Also it's broken if zlib is used (on SmartOS at least) because configure can't find it.

Since the Joyent build breaks only on the inet6 message file when doing bmake install, and the zlib issue pops up earlier I'd like to also hereby request that it be built with the 'unrealircd-ziplinks' option added.

En passant I've also included an SMF manifest. 
