### PR TITLE
Revive security/pam-radius

### DIFF
--- a/security/pam-radius/Makefile
+++ b/security/pam-radius/Makefile
@@ -2,6 +2,7 @@
 
 PKGNAME=	${DISTNAME:S/_/-/}
 DISTNAME=	pam_radius-1.4.0
+PKGREVISION=	1
 CATEGORIES=	security
 MASTER_SITES=	ftp://ftp.freeradius.org/pub/freeradius/
 

--- a/security/pam-radius/distinfo
+++ b/security/pam-radius/distinfo
@@ -4,5 +4,6 @@ SHA1 (pam_radius-1.4.0.tar.gz) = 161af24355b79736bb63ba1cf9e627f9ca6e1671
 RMD160 (pam_radius-1.4.0.tar.gz) = 765bf1d81243504b6fccbab4032baba424dd8d33
 SHA512 (pam_radius-1.4.0.tar.gz) = 3505e3de6777c4129a36d2dbd1ae1dbdc5fe46d752c58a6f2a325f77d6f41f7bd999b886f830c0631e51112f756a16e699f29daa428c2befc79cfab5e5b58624
 Size (pam_radius-1.4.0.tar.gz) = 179458 bytes
-SHA1 (patch-configure) = 50cdf0f778d3b48e8c06f9871dcf3ef0efa4cdee
+SHA1 (patch-configure) = aebfb57019dc18c42ff71c5317123634e7a788cd
+SHA1 (patch-configure.ac) = 41ef7a4fbb768ef8c8df31e016f3702d249ed184 
 SHA1 (patch-src_pam__radius__auth.h) = e17931e1789636f6bccf80e51d2f875d36ed7681

--- a/security/pam-radius/patches/patch-configure
+++ b/security/pam-radius/patches/patch-configure
@@ -1,10 +1,21 @@
-$NetBSD: patch-configure,v 1.1 2015/12/24 23:40:27 dholland Exp $
-
-Fix shell conditional.
-
---- configure~	2014-12-17 22:00:59.000000000 +0000
+--- configure~	2016-03-31 10:45:47.232484950 -0400
 +++ configure
-@@ -5261,7 +5261,7 @@ fi
+@@ -4540,7 +4540,13 @@
+ for ac_header in security/pam_modules.h pam/pam_modules.h
+ do :
+   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+-ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
++ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "
++   #ifdef HAVE_SECURITY_PAM_APPL_H
++   #  include <security/pam_appl.h>
++   #endif
++
++
++"
+ if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+   cat >>confdefs.h <<_ACEOF
+ #define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+@@ -5261,7 +5267,7 @@
  HOSTINFO=$host
  
  
@@ -13,3 +24,12 @@ Fix shell conditional.
    CFLAGS="-Werror $CFLAGS"
  fi
  
+@@ -5870,6 +5876,8 @@
+   case $ac_option in
+   # Handling of the options.
+   -recheck | --recheck | --rechec | --reche | --rech | --rec | --re | --r)
++	: Avoid regenerating within pkgsrc
++	exit 0
+     ac_cs_recheck=: ;;
+   --version | --versio | --versi | --vers | --ver | --ve | --v | -V )
+     $as_echo "$ac_cs_version"; exit ;;

--- a/security/pam-radius/patches/patch-configure.ac
+++ b/security/pam-radius/patches/patch-configure.ac
@@ -1,0 +1,17 @@
+--- configure.ac~	2016-03-31 10:27:10.555823320 -0400
++++ configure.ac
+@@ -179,7 +179,13 @@
+ )
+ 
+ AC_CHECK_HEADERS(security/pam_appl.h pam/pam_appl.h)
+-AC_CHECK_HEADERS(security/pam_modules.h pam/pam_modules.h)
++AC_CHECK_HEADERS(security/pam_modules.h pam/pam_modules.h, [], [],
++  [
++    #ifdef HAVE_SECURITY_PAM_APPL_H
++    #  include <security/pam_appl.h>
++    #endif
++  ]
++)
+ if test x"$ac_cv_header_security_pam_modules_h" != x"yes" -a x"$ac_cv_header_pam_modules_appl_h" != x"yes"; then
+ 	AC_MSG_ERROR([pam_modules.h not found])
+ fi


### PR DESCRIPTION
Pulls in a fix from FreeRadius' pam-radius head to restore building on systems using Solaris or Illumos libpam headers.  Once FreeRadius cuts a new pam-radius release these patches should be able to go away.
