### PR TITLE
Python 3.x doesn't include Berkeley DB support internally and unneces…

### DIFF
--- a/lang/python34/Makefile
+++ b/lang/python34/Makefile
@@ -83,7 +83,7 @@ PLIST.oss=	yes
 CFLAGS+=		-I${OSX_SDK_PATH:Q}/usr/include
 .endif
 
-PLIST_VARS+=	bsddb dll nis no-nis
+PLIST_VARS+=	dll nis no-nis
 .if ${OPSYS} == "IRIX"
 .  if ${ABI} == "64"
 PLIST.no-nis=	yes
@@ -91,21 +91,12 @@ PLIST.no-nis=	yes
 PLIST.nis=	yes
 .  endif
 .else
-.  include "../../mk/bdb.buildlink3.mk"
-MAKE_ENV+=	PY_BDB_TYPE=${BDB_TYPE}
-MAKE_ENV+=	PY_BDB_INCDIRS=${BUILDLINK_INCDIRS.${BDB_TYPE}:S,^,${BDBBASE}/,:Q}
-MAKE_ENV+=	PY_BDB_LIBDIRS=${BDBBASE}/lib
-PLIST.bsddb=	yes
 PLIST.dll=	yes
 .  if ${OPSYS} != "NetBSD" || exists(/usr/bin/ypcat)
 PLIST.nis=	yes
 .  else
 PLIST.no-nis=	yes
 .  endif
-.endif
-
-.if defined(BUILDLINK_TRANSFORM)
-MAKE_ENV+=	PY_BDB_TRANSFORM=${BUILDLINK_TRANSFORM:Q}
 .endif
 
 PLIST_SUBST+=	PY_VER_SUFFIX=${PY_VER_SUFFIX:Q}

--- a/lang/python35/Makefile
+++ b/lang/python35/Makefile
@@ -83,7 +83,7 @@ PLIST.oss=	yes
 CFLAGS+=		-I${OSX_SDK_PATH:Q}/usr/include
 .endif
 
-PLIST_VARS+=	bsddb dll nis no-nis
+PLIST_VARS+=	dll nis no-nis
 .if ${OPSYS} == "IRIX"
 .  if ${ABI} == "64"
 PLIST.no-nis=	yes
@@ -91,21 +91,12 @@ PLIST.no-nis=	yes
 PLIST.nis=	yes
 .  endif
 .else
-.  include "../../mk/bdb.buildlink3.mk"
-MAKE_ENV+=	PY_BDB_TYPE=${BDB_TYPE}
-MAKE_ENV+=	PY_BDB_INCDIRS=${BUILDLINK_INCDIRS.${BDB_TYPE}:S,^,${BDBBASE}/,:Q}
-MAKE_ENV+=	PY_BDB_LIBDIRS=${BDBBASE}/lib
-PLIST.bsddb=	yes
 PLIST.dll=	yes
 .  if ${OPSYS} != "NetBSD" || exists(/usr/bin/ypcat)
 PLIST.nis=	yes
 .  else
 PLIST.no-nis=	yes
 .  endif
-.endif
-
-.if defined(BUILDLINK_TRANSFORM)
-MAKE_ENV+=	PY_BDB_TRANSFORM=${BUILDLINK_TRANSFORM:Q}
 .endif
 
 PLIST_SUBST+=	PY_VER_SUFFIX=${PY_VER_SUFFIX:Q}


### PR DESCRIPTION
…ary paths are harmful for other python modules

This patch should be applied to all active pkgsrc branches and to Python 3.6 in pkgsrc current.