### PR TITLE
Fix so logrotate compiles on SmartOS again

### DIFF
--- a/sysutils/logrotate/distinfo
+++ b/sysutils/logrotate/distinfo
@@ -7,3 +7,4 @@ Size (ca742b9dd72b7815e87cb53331f08d46fe21d86c.tar.gz) = 78769 bytes
 SHA1 (patch-examples_logrotate-default) = 57fc602caa5eeaa830f5d2dc0667e11330bcd1e8
 SHA1 (patch-examples_logrotate.cron) = 02981cb2b49e3f3f500fcb3db9b5dcb5fe62bddc
 SHA1 (patch-logrotate.8) = 0bf7d9cfbc2f5dfff42a82b523926b9c8d0362a0
+SHA1 (patch-logrotate.c) = b469438fb1198bcec426f215427449b7ea255586

--- a/sysutils/logrotate/patches/patch-logrotate.c
+++ b/sysutils/logrotate/patches/patch-logrotate.c
@@ -1,0 +1,26 @@
+$NetBSD$
+
+Fixes GCC error:
+"error: missing sentinel in function call [-Werror=format=]"
+
+
+--- logrotate.c.orig    2016-08-03 09:01:44.000000000 +0000
++++ logrotate.c
+@@ -352,7 +352,7 @@ static int runScript(struct logInfo *log
+                                DOEXIT(1);
+                        }
+                }
+-               execl("/bin/sh", "sh", "-c", script, "logrotate_script", logfn, NULL);
++               execl("/bin/sh", "sh", "-c", script, "logrotate_script", logfn, (char *)NULL);
+                DOEXIT(1);
+        }
+
+@@ -672,7 +672,7 @@ static int mailLog(struct logInfo *log,
+                                DOEXIT(1);
+                        }
+
+-                       execlp(uncompressCommand, uncompressCommand, NULL);
++                       execlp(uncompressCommand, uncompressCommand, (char *)NULL);
+                        DOEXIT(1);
+                }
+


### PR DESCRIPTION
Fixes logrotate GCC errors so it compiles once again on SmartOS. Likely
affects other OS's too depending on GCC version/configuration