### PR TITLE
SMF uses wrong (old?) flags

### DIFF
--- a/www/varnish/files/smf/manifest.xml
+++ b/www/varnish/files/smf/manifest.xml
@@ -11,7 +11,7 @@
       <service_fmri value="svc:/system/filesystem/local" />
     </dependency>
     <method_context>
-      <method_credential user='varnish' group='varnish' />
+      <method_credential user='@VRNUSER@' group='@VRNGROUP@' />
       <method_environment>
         <envvar name='PATH' value='@PREFIX@/sbin:@PREFIX@/bin:/sbin:/usr/sbin:/usr/bin' />
       </method_environment>

--- a/www/varnish/files/smf/manifest.xml
+++ b/www/varnish/files/smf/manifest.xml
@@ -11,18 +11,19 @@
       <service_fmri value="svc:/system/filesystem/local" />
     </dependency>
     <method_context>
+      <method_credential user='varnish' group='varnish' />
       <method_environment>
         <envvar name='PATH' value='@PREFIX@/sbin:@PREFIX@/bin:/sbin:/usr/sbin:/usr/bin' />
       </method_environment>
     </method_context>
-    <exec_method type="method" name="start" exec="@PREFIX@/sbin/varnishd -a %{listen} -l %{size} -f %{config_file} -u @VRNUSER@ -g @VRNGROUP@" timeout_seconds="60" />
+    <exec_method type="method" name="start" exec="@PREFIX@/sbin/varnishd -j solaris -a %{listen} -l %{size} -f %{config_file}" timeout_seconds="60" />
     <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60" />
     <property_group name="startd" type="framework">
       <propval name="duration" type="astring" value="contract" />
       <propval name="ignore_error" type="astring" value="core,signal" />
     </property_group>
     <property_group name="application" type="application">
-      <propval name="config_file" type="astring" value="@PKG_SYSCONFDIR@/default.vcl" />
+      <propval name="config_file" type="astring" value="@PKG_SYSCONFDIR@/example.vcl" />
       <propval name="listen" type="astring" value="0.0.0.0:8080" />
       <propval name="size" type="astring" value="64M" />
     </property_group>


### PR DESCRIPTION
The actual invocation is correct and default.vcl doesn't exist any more. I added '-j solaris' but does this break upstream (ie NetBSD)?