### PR TITLE
Adjust ipv4 address to listen on localhost

### DIFF
--- a/www/varnish/files/smf/manifest.xml
+++ b/www/varnish/files/smf/manifest.xml
@@ -23,7 +23,7 @@
     </property_group>
     <property_group name="application" type="application">
       <propval name="config_file" type="astring" value="@PKG_SYSCONFDIR@/default.vcl" />
-      <propval name="listen" type="astring" value="0.0.0.0:8080" />
+      <propval name="listen" type="astring" value="127.0.0.1:8080" />
       <propval name="size" type="astring" value="64M" />
     </property_group>
     <template>


### PR DESCRIPTION
Start daemon on localhost instead of 0.0.0.0:8080 as this prevents varnishd from trying to bind to 8080 twice which results in error: 
Error: Could not get socket 0.0.0.0:8080: Address already in use
(-? gives usage)

Similar case to memcached.

svccfg -s pkgsrc/varnish setprop application/listen = 10.1.1.1:8080
svcadm refresh pkgsrc/varnish
svcprop -p application/listen pkgsrc/varnish
svcadm restart pkgsrc/varnish