### PR TITLE
Backport imagemagick6 to 2016Q4 from trunk to upgrade to latest patch release and fix CVE

### DIFF
--- a/graphics/ImageMagick6/Makefile
+++ b/graphics/ImageMagick6/Makefile
@@ -1,6 +1,5 @@
-# $NetBSD: Makefile,v 1.3 2016/12/17 00:39:17 rodent Exp $
+# $NetBSD: Makefile,v 1.9 2017/10/30 15:08:13 fhajny Exp $
 
-PKGREVISION= 1
 .include "Makefile.common"
 
 PKGNAME=	ImageMagick6-${DISTVERSION}
@@ -45,6 +44,7 @@ SUBST_SED.pkgcfg+=	-e 's|s: MagickCore|s: MagickCore-6.Q16|g'
 SUBST_SED.pkgcfg+=	-e 's|Magick++-config|Magick++-config6|g'
 SUBST_SED.pkgcfg+=	-e 's|Magick-config |Magick-config6 |g'
 SUBST_SED.pkgcfg+=	-e 's|s Magick++|s Magick++-6.Q16|g'
+SUBST_SED.pkgcfg+=	-e 's|@PKG_CONFIG@|${PREFIX}/bin/pkg-config|g'
 SUBST_STAGE.pkgcfg=	pre-configure
 
 GCC_REQD+=		2.95.3

--- a/graphics/ImageMagick6/Makefile.common
+++ b/graphics/ImageMagick6/Makefile.common
@@ -1,9 +1,10 @@
-# $NetBSD: Makefile.common,v 1.1 2016/05/25 12:41:17 ryoon Exp $
+# $NetBSD: Makefile.common,v 1.11 2017/10/30 15:08:13 fhajny Exp $
 #
-# used by graphics/p5-PerlMagick/Makefile
+# When updating this package, please upload the distfile
+# since they disappear immediately when new releases happen.
 
-IM_MAJOR_VER=		6.9.4
-IM_MINOR_VER=		4
+IM_MAJOR_VER=		6.9.9
+IM_MINOR_VER=		20
 IM_MAJOR_LIB_VER=	6
 
 .if (${IM_MINOR_VER} != NONE)
@@ -16,10 +17,10 @@ DISTNAME=	ImageMagick-${DISTSUFFIX}
 DISTVERSION=	${DISTSUFFIX:S/-/./}
 
 CATEGORIES=	graphics
-MASTER_SITES=	ftp://ftp.imagemagick.org/pub/ImageMagick/ \
-		ftp://ftp.nluug.nl/pub/ImageMagick/ \
-		ftp://ftp.kddlabs.co.jp/graphics/ImageMagick/ \
-		http://www.imagemagick.org/download/
+MASTER_SITES=	ftp://ftp.imagemagick.org/pub/ImageMagick/
+MASTER_SITES+=	ftp://ftp.nluug.nl/pub/ImageMagick/
+MASTER_SITES+=	ftp://ftp.kddlabs.co.jp/graphics/ImageMagick/
+MASTER_SITES+=	http://www.imagemagick.org/download/
 EXTRACT_SUFX=	.tar.xz
 
 HOMEPAGE=	http://www.imagemagick.org/

--- a/graphics/ImageMagick6/PLIST
+++ b/graphics/ImageMagick6/PLIST
@@ -1,4 +1,4 @@
-@comment $NetBSD: PLIST,v 1.1 2016/05/25 12:41:17 ryoon Exp $
+@comment $NetBSD: PLIST,v 1.5 2017/10/30 15:08:13 fhajny Exp $
 bin/Magick++-config6
 bin/Magick-config6
 bin/MagickCore-config6
@@ -33,7 +33,6 @@ include/ImageMagick-6/Magick++/STL.h
 include/ImageMagick-6/Magick++/TypeMetric.h
 include/ImageMagick-6/magick/ImageMagick.h
 include/ImageMagick-6/magick/MagickCore.h
-include/ImageMagick-6/magick/accelerate.h
 include/ImageMagick-6/magick/animate.h
 include/ImageMagick-6/magick/annotate.h
 include/ImageMagick-6/magick/api.h
@@ -150,7 +149,7 @@ include/ImageMagick-6/wand/pixel-iterator.h
 include/ImageMagick-6/wand/pixel-wand.h
 include/ImageMagick-6/wand/stream.h
 include/ImageMagick-6/wand/wand-view.h
-lib/ImageMagick-6.9.4/config-Q16/configure.xml
+lib/ImageMagick-6.9.9/config-Q16/configure.xml
 lib/libMagick++-6.Q16.la
 lib/libMagickCore-6.Q16.la
 lib/libMagickWand-6.Q16.la
@@ -1130,6 +1129,7 @@ share/doc/ImageMagick-6/www/contact.html
 share/doc/ImageMagick-6/www/convert.html
 share/doc/ImageMagick-6/www/css/README.txt
 share/doc/ImageMagick-6/www/css/magick.css
+share/doc/ImageMagick-6/www/develop.html
 share/doc/ImageMagick-6/www/display.html
 share/doc/ImageMagick-6/www/distribute-pixel-cache.html
 share/doc/ImageMagick-6/www/download.html
@@ -1154,9 +1154,12 @@ share/doc/ImageMagick-6/www/license.html
 share/doc/ImageMagick-6/www/links.html
 share/doc/ImageMagick-6/www/magick++.html
 share/doc/ImageMagick-6/www/magick-core.html
+share/doc/ImageMagick-6/www/magick-script.html
 share/doc/ImageMagick-6/www/magick-vector-graphics.html
 share/doc/ImageMagick-6/www/magick-wand.html
+share/doc/ImageMagick-6/www/magick.html
 share/doc/ImageMagick-6/www/miff.html
+share/doc/ImageMagick-6/www/mirror.html
 share/doc/ImageMagick-6/www/mogrify.html
 share/doc/ImageMagick-6/www/montage.html
 share/doc/ImageMagick-6/www/motion-picture.html
@@ -1167,6 +1170,7 @@ share/doc/ImageMagick-6/www/porting.html
 share/doc/ImageMagick-6/www/quantize.html
 share/doc/ImageMagick-6/www/resources.html
 share/doc/ImageMagick-6/www/search.html
+share/doc/ImageMagick-6/www/security-policy.html
 share/doc/ImageMagick-6/www/sitemap.html
 share/doc/ImageMagick-6/www/source/analyze.c
 share/doc/ImageMagick-6/www/source/coder.xml
@@ -1191,7 +1195,6 @@ share/doc/ImageMagick-6/www/source/type-ghostscript.xml
 share/doc/ImageMagick-6/www/source/type-windows.xml
 share/doc/ImageMagick-6/www/source/type.xml
 share/doc/ImageMagick-6/www/source/wand.c
-share/doc/ImageMagick-6/www/sponsors.html
 share/doc/ImageMagick-6/www/stream.html
 share/doc/ImageMagick-6/www/support.html
 share/doc/ImageMagick-6/www/wand.png
@@ -1208,5 +1211,6 @@ share/examples/ImageMagick6/thresholds.xml
 share/examples/ImageMagick6/type-apple.xml
 share/examples/ImageMagick6/type-dejavu.xml
 share/examples/ImageMagick6/type-ghostscript.xml
+share/examples/ImageMagick6/type-urw-base35.xml
 share/examples/ImageMagick6/type-windows.xml
 share/examples/ImageMagick6/type.xml

--- a/graphics/ImageMagick6/buildlink3.mk
+++ b/graphics/ImageMagick6/buildlink3.mk
@@ -1,4 +1,4 @@
-# $NetBSD: buildlink3.mk,v 1.1 2016/05/25 12:41:17 ryoon Exp $
+# $NetBSD: buildlink3.mk,v 1.3 2017/10/30 14:44:05 fhajny Exp $
 
 BUILDLINK_TREE+=	ImageMagick6
 
@@ -6,7 +6,7 @@ BUILDLINK_TREE+=	ImageMagick6
 IMAGEMAGICK6_BUILDLINK3_MK:=
 
 BUILDLINK_API_DEPENDS.ImageMagick6+=	ImageMagick6>=5.5.7.11nb1
-BUILDLINK_ABI_DEPENDS.ImageMagick6+=	ImageMagick6>=6.9.1.7nb2
+BUILDLINK_ABI_DEPENDS.ImageMagick6+=	ImageMagick6>=6.9.7.9nb1
 BUILDLINK_PKGSRCDIR.ImageMagick6?=	../../graphics/ImageMagick6
 
 pkgbase := ImageMagick6
@@ -15,8 +15,8 @@ pkgbase := ImageMagick6
 .if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mdjvu)
 .include "../../graphics/djvulibre-lib/buildlink3.mk"
 .endif
-.if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mjasper)
-.include "../../graphics/jasper/buildlink3.mk"
+.if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mjp2)
+.include "../../graphics/openjpeg/buildlink3.mk"
 .endif
 .if !empty(PKG_BUILD_OPTIONS.ImageMagick6:Mopenexr)
 .include "../../graphics/openexr/buildlink3.mk"

--- a/graphics/ImageMagick6/distinfo
+++ b/graphics/ImageMagick6/distinfo
@@ -1,7 +1,7 @@
-$NetBSD: distinfo,v 1.1 2016/05/25 12:41:17 ryoon Exp $
+$NetBSD: distinfo,v 1.8 2017/10/30 15:08:13 fhajny Exp $
 
-SHA1 (ImageMagick-6.9.4-4.tar.xz) = 7125619549d94989d5bb41017b142dc06079ed32
-RMD160 (ImageMagick-6.9.4-4.tar.xz) = 5af4ec8fc5a14b47d88bbf98e19317f2d4b5d6f3
-SHA512 (ImageMagick-6.9.4-4.tar.xz) = 443bbb68d99ae76cc025cc632578ac04ff7166ae82b01ba7e7dcff3804f926fd69ef42549141248c955e487b4383a48bb880a13217a744180fc51f4395e6e3e0
-Size (ImageMagick-6.9.4-4.tar.xz) = 8778596 bytes
+SHA1 (ImageMagick-6.9.9-20.tar.xz) = 551b9684a0ec02b8993f59ed127cd13d976516a6
+RMD160 (ImageMagick-6.9.9-20.tar.xz) = f52fe28e5988d08083428d1a21fae8921f9526b0
+SHA512 (ImageMagick-6.9.9-20.tar.xz) = 36c241490ee41de5cd72e5bc297ac2353a0d4574337776445798b0c5823f491304c3f3a728d420d03f66b652eafcdb68ec2992347321ac3919c1d72c0afdb849
+Size (ImageMagick-6.9.9-20.tar.xz) = 8994128 bytes
 SHA1 (patch-Makefile.in) = bb747b5e062f2a59e307289b5b33861dd5f96ab0

--- a/graphics/ImageMagick6/options.mk
+++ b/graphics/ImageMagick6/options.mk
@@ -1,8 +1,9 @@
-# $NetBSD: options.mk,v 1.1 2016/05/25 12:41:17 ryoon Exp $
+# $NetBSD: options.mk,v 1.2 2017/10/30 14:44:05 fhajny Exp $
 
 PKG_OPTIONS_VAR=	PKG_OPTIONS.ImageMagick
-PKG_SUPPORTED_OPTIONS=	x11 jasper djvu openexr wmf
-PKG_SUGGESTED_OPTIONS=	x11 jasper
+PKG_SUPPORTED_OPTIONS=	x11 jp2 djvu openexr wmf
+PKG_SUGGESTED_OPTIONS=	x11 jp2
+PKG_OPTIONS_LEGACY_OPTS+=	jasper:jp2
 
 .include "../../mk/bsd.options.mk"
 
@@ -14,12 +15,11 @@ PKG_SUGGESTED_OPTIONS=	x11 jasper
 CONFIGURE_ARGS+=	--without-x
 .endif
 
-.if !empty(PKG_OPTIONS:Mjasper)
-BUILDLINK_API_DEPENDS.jasper+=	jasper>=1.701.0
-.include "../../graphics/jasper/buildlink3.mk"
-CONFIGURE_ARGS+=	--with-jp2
+.if !empty(PKG_OPTIONS:Mjp2)
+.include "../../graphics/openjpeg/buildlink3.mk"
+CONFIGURE_ARGS+=	--with-openjp2
 .else
-CONFIGURE_ARGS+=	--without-jp2
+CONFIGURE_ARGS+=	--without-openjp2
 .endif
 
 .if !empty(PKG_OPTIONS:Mdjvu)


### PR DESCRIPTION
This backport will also restore jp2 format support which was incorrectly missing