### PR TITLE
Bumps pcre to version 8.41 by backporting from trunk

### DIFF
--- a/devel/pcre/Makefile
+++ b/devel/pcre/Makefile
@@ -1,9 +1,9 @@
-# $NetBSD: Makefile,v 1.80 2016/06/19 20:40:48 wiz Exp $
+# $NetBSD: Makefile,v 1.85 2017/07/06 06:27:42 adam Exp $
 
-DISTNAME=	pcre-8.39
+DISTNAME=	pcre-8.41
 CATEGORIES=	devel
-MASTER_SITES=	ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/ \
-		${MASTER_SITE_SOURCEFORGE:=pcre/}
+MASTER_SITES=	ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/
+MASTER_SITES+=	${MASTER_SITE_SOURCEFORGE:=pcre/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pkgsrc-users@NetBSD.org

--- a/devel/pcre/distinfo
+++ b/devel/pcre/distinfo
@@ -1,9 +1,9 @@
-$NetBSD: distinfo,v 1.61 2016/06/19 20:40:48 wiz Exp $
+$NetBSD: distinfo,v 1.65 2017/07/06 06:27:42 adam Exp $
 
-SHA1 (pcre-8.39.tar.bz2) = 5e38289fd1b4ef3e8426f31a01e34b6924d80b90
-RMD160 (pcre-8.39.tar.bz2) = bd3353494b85f184ebe3ba0de55584c3b9e74658
-SHA512 (pcre-8.39.tar.bz2) = 8b0f14ae5947c4b2d74876a795b04e532fd71c2479a64dbe0ed817e7c7894ea3cae533413de8c17322d305cb7f4e275d72b43e4e828eaca77dc4bcaf04529cf6
-Size (pcre-8.39.tar.bz2) = 1560758 bytes
+SHA1 (pcre-8.41.tar.bz2) = 7d1f4aae4191512744a718cc2b81bcf995ec1437
+RMD160 (pcre-8.41.tar.bz2) = 29342fea75514f96553149b18c44eae0abe86b9d
+SHA512 (pcre-8.41.tar.bz2) = cc9cdbeb98c010fe4f093a019bebfb91965dae4c6a48f8e49c38ec8df7d9da7f0d32c12fc58f22c51f1c2f010e72b65bcbf8bbf180060e93edf464fa9a7c3551
+Size (pcre-8.41.tar.bz2) = 1561874 bytes
 SHA1 (patch-aa) = ed20cfb5ca7b1e620e368c8e41a7f691d6f93282
 SHA1 (patch-ab) = 0b8fbde09c27e2716e5bfa32abce8ee4a79fb7fb
 SHA1 (patch-doc_pcredemo.3) = 90f9b3a021f58973149d839735d40c5e2e245912


### PR DESCRIPTION
Fixes CVEs

* https://nvd.nist.gov/vuln/detail/CVE-2017-11164
* https://nvd.nist.gov/vuln/detail/CVE-2017-7186
* https://nvd.nist.gov/vuln/detail/CVE-2017-7244
* https://nvd.nist.gov/vuln/detail/CVE-2017-7245
* https://nvd.nist.gov/vuln/detail/CVE-2017-7246
* https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-6004
* https://nvd.nist.gov/vuln/detail/CVE-2017-7244