### PR TITLE
Backports git from 2017Q4

### DIFF
--- a/devel/git-base/Makefile
+++ b/devel/git-base/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.42 2017/08/07 17:56:14 adam Exp $
+# $NetBSD: Makefile,v 1.46 2017/09/27 06:37:47 adam Exp $
 
 .include "../../devel/git/Makefile.common"
 
@@ -108,6 +108,7 @@ post-install:
 .include "options.mk"
 
 .include "../../converters/libiconv/buildlink3.mk"
+.include "../../devel/gettext-lib/buildlink3.mk"
 .include "../../devel/pcre2/buildlink3.mk"
 .include "../../devel/zlib/buildlink3.mk"
 .include "../../lang/perl5/module.mk"

--- a/devel/git-base/PLIST
+++ b/devel/git-base/PLIST
@@ -1,4 +1,4 @@
-@comment $NetBSD: PLIST,v 1.16 2017/05/10 18:09:25 adam Exp $
+@comment $NetBSD: PLIST,v 1.17 2017/11/02 06:18:11 adam Exp $
 bin/git
 bin/git-cvsserver
 bin/git-receive-pack
@@ -210,6 +210,7 @@ share/examples/git/templates/info/exclude
 share/locale/bg/LC_MESSAGES/git.mo
 share/locale/ca/LC_MESSAGES/git.mo
 share/locale/de/LC_MESSAGES/git.mo
+share/locale/es/LC_MESSAGES/git.mo
 share/locale/fr/LC_MESSAGES/git.mo
 share/locale/is/LC_MESSAGES/git.mo
 share/locale/it/LC_MESSAGES/git.mo

--- a/devel/git-base/distinfo
+++ b/devel/git-base/distinfo
@@ -1,9 +1,9 @@
-$NetBSD: distinfo,v 1.70 2017/08/12 22:05:15 adam Exp $
+$NetBSD: distinfo,v 1.74 2017/11/30 07:50:01 adam Exp $
 
-SHA1 (git-2.14.1.tar.xz) = 33af2185b1a99ea6581f270d0bb497ca1ca015a8
-RMD160 (git-2.14.1.tar.xz) = 20883121f8b167d52cd54107e78a9d8a0a7502a9
-SHA512 (git-2.14.1.tar.xz) = bee35ad9c6a0d0588045ec2fe5f6987cb1eeb3961cdf33cd9b51ae52017969131ea4ec09908f9b30944f85b0daa99614fb42c248c9c8dac5f21a90e2866c33b4
-Size (git-2.14.1.tar.xz) = 4791876 bytes
+SHA1 (git-2.15.1.tar.xz) = 0ff2d0c64621f92e15759b2ca07838858bef8ff0
+RMD160 (git-2.15.1.tar.xz) = 4faa07120bec5376a76330cdebe5b43e283856d7
+SHA512 (git-2.15.1.tar.xz) = dcf300b28e41f7757d866e768d641137718b43eb6d12a2cfff99fb429775e0cab87bbff48147b8588bc0f69e92eb5ca2ad1f75c8cf5205e41853d8e8652f900b
+Size (git-2.15.1.tar.xz) = 4894768 bytes
 SHA1 (patch-aa) = a58f3c2f45c1fbafd751d10b9ef34e6c9afc2c6f
 SHA1 (patch-ac) = e5d2112d158fe493a89b244a10d2e4b998a23d98
 SHA1 (patch-ae) = 9bc2e6c7f0a8fbc385b6ffda638d3245a62dc5ca

--- a/devel/git/Makefile.common
+++ b/devel/git/Makefile.common
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile.common,v 1.5 2016/05/31 13:38:14 leot Exp $
+# $NetBSD: Makefile.common,v 1.6 2017/08/16 20:21:06 wiz Exp $
 #
 # used by devel/git-base/Makefile
 # used by devel/git-contrib/Makefile
@@ -14,7 +14,7 @@ MASTER_SITES?=	https://www.kernel.org/pub/software/scm/git/
 EXTRACT_SUFX=	.tar.xz
 
 MAINTAINER?=	pkgsrc-users@NetBSD.org
-HOMEPAGE?=	http://git-scm.com/
+HOMEPAGE?=	https://git-scm.com/
 LICENSE=	gnu-gpl-v2
 
 .include "../../mk/bsd.fast.prefs.mk"

--- a/devel/git/Makefile.version
+++ b/devel/git/Makefile.version
@@ -1,7 +1,7 @@
-# $NetBSD: Makefile.version,v 1.61 2017/08/12 22:05:15 adam Exp $
+# $NetBSD: Makefile.version,v 1.65 2017/11/30 07:50:01 adam Exp $
 #
 # used by devel/git/Makefile.common
 # used by devel/git-cvs/Makefile
 # used by devel/git-svn/Makefile
 
-GIT_VERSION=	2.14.1
+GIT_VERSION=	2.15.1


### PR DESCRIPTION
Bug fixes and brings it inline with 2015Q4 (outstanding pull for
security fixes)